### PR TITLE
fix the shrink-var call

### DIFF
--- a/shrinking.rkt
+++ b/shrinking.rkt
@@ -17,7 +17,7 @@
         ['() v]
         [(cons v vs)
          (if (equal? (check-property prop (dict-set env x v)) 'fail)
-             (shrink-var env x v shrinker)
+             (shrink-var (dict-set env x v) x shrinker)
              (loop vs))])))
   (for/fold ([env env])
             ([x (property-variables prop)])


### PR DESCRIPTION
`shrink-var` takes 3 arguments, the previous code was using `shrink-var` with 4. This PR fixes the problem.